### PR TITLE
Fix db name in serverless.yml to avoid duplicates

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -40,7 +40,7 @@ resources:
     appReviewsTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: appReviewsTable
+        TableName: appReviewsTable-${self:provider.stage}
         AttributeDefinitions:
           - AttributeName: id
             AttributeType: S


### PR DESCRIPTION
AWS was complaining about duplicate tables when I tried to "sls deploy" - this will include the stage in the DB Table name to avoid conflicts.