### PR TITLE
Secondary indexes

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -40,18 +40,18 @@ resources:
     appReviewsTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: appReviewsTable-${self:provider.stage}
+        TableName: reviewsTable-${self:provider.stage}
         AttributeDefinitions:
-          - AttributeName: id
+          - AttributeName: appId
             AttributeType: S
-          - AttributeName: reviewDate
+          - AttributeName: versionDate
             AttributeType: S
           - AttributeName: compSentiment
             AttributeType: N
         KeySchema:
-          - AttributeName: id
+          - AttributeName: appId
             KeyType: HASH
-          - AttributeName: reviewDate
+          - AttributeName: versionDate
             KeyType: RANGE
         ProvisionedThroughput:
           ReadCapacityUnits: 5
@@ -61,7 +61,7 @@ resources:
             IndexName: sentiment
             KeySchema:
               -
-                AttributeName: id
+                AttributeName: appId
                 KeyType: HASH
               -
                 AttributeName: compSentiment

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -44,13 +44,40 @@ resources:
         AttributeDefinitions:
           - AttributeName: id
             AttributeType: S
-          - AttributeName: store
+          - AttributeName: reviewDate
             AttributeType: S
+          - AttributeName: compSentiment
+            AttributeType: N
+          # - AttributeName: posSentiment
+          #   AttributeType: N
+          # - AttributeName: neuSentiment
+          #   AttributeType: N
+          # - AttributeName: negSentiment
+          #   AttributeType: N
         KeySchema:
           - AttributeName: id
             KeyType: HASH
-          - AttributeName: store
+          - AttributeName: reviewDate
             KeyType: RANGE
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5
+        GlobalSecondaryIndexes:
+          -
+            IndexName: sentiment
+            KeySchema:
+              -
+                AttributeName: id
+                KeyType: HASH
+              -
+                AttributeName: compSentiment
+                KeyType: RANGE
+            Projection:
+              NonKeyAttributes:
+                - posSentiment
+                - neuSentiment
+                - negSentiment
+              ProjectionType: INCLUDE
+            ProvisionedThroughput:
+              ReadCapacityUnits: 5
+              WriteCapacityUnits: 5

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -48,12 +48,6 @@ resources:
             AttributeType: S
           - AttributeName: compSentiment
             AttributeType: N
-          # - AttributeName: posSentiment
-          #   AttributeType: N
-          # - AttributeName: neuSentiment
-          #   AttributeType: N
-          # - AttributeName: negSentiment
-          #   AttributeType: N
         KeySchema:
           - AttributeName: id
             KeyType: HASH


### PR DESCRIPTION
I changed the name of the table to make it easier to deploy - serverless won't let you deploy an updated table with the same name, so we'll have to keep changing it (probably between "appReviewsTable" and "reviewsTable") until the schema is finalized.

The primary hash key is a combination of app ID and store, while the primary sort key is a combination of app version and review date. Additionally, I included some syntax for a global secondary index on sentiment - probably not what the final version will look like, but useful for reference down the road.