### PR TITLE
Update CloudWatch Rule whenever interval settings change

### DIFF
--- a/backend/main/pom.xml
+++ b/backend/main/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>aws-java-sdk-lambda</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-events</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context-indexer</artifactId>
         <version>5.1.0.RELEASE</version>

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -31,12 +31,21 @@ provider:
             - 'arn:aws:ssm'
             - Ref: 'AWS::Region'
             - Ref: 'AWS::AccountId'
+    - Effect: Allow
+      Action:
+        - events:PutRule
+      Resource:
+        - arn:aws:events:${self:provider.region}:*:rule/${self:custom.reviewsEventName}
+        - arn:aws:events:${self:provider.region}:*:rule/${self:custom.slackbotEventName}
 
 plugins:
     - serverless-finch
 
 custom:
   tableName: 'appReviewsTable-${self:provider.stage}'
+
+  reviewsEventName: reviews-interval-${self:provider.stage}
+  slackbotEventName: slackbot-interval-${self:provider.stage}
   
   client:
     bucketName: ${self:service}-client-${self:provider.stage}
@@ -61,6 +70,10 @@ functions:
       TABLE_NAME: ${self:custom.tableName}
       DEPLOY_REGION: ${self:provider.region}
       STAGE: ${self:provider.stage}
+
+      # Flags for settings that require Lambda configuration updates
+      APPSTOREPOLLING_CLOUDWATCH_EVENT: ${self:custom.reviewsEventName}
+      POSTINGINTERVAL_CLOUDWATCH_EVENT: ${self:custom.slackbotEventName}
     events:
       - http:
           method: post
@@ -100,6 +113,9 @@ functions:
       - http:
           method: any
           path: reviews
+      - schedule:
+          name: ${self:custom.reviewsEventName}
+          rate: rate(30 minutes)
   slackbot:
     runtime: nodejs8.10
     timeout: 20
@@ -124,6 +140,9 @@ functions:
       - http:
           method: get
           path: slackbot
+      - schedule:
+          name: ${self:custom.slackbotEventName}
+          rate: rate(30 minutes)
 
 resources:
   Resources:


### PR DESCRIPTION
CloudWatch Rules now update whenever Lambda intervals are changed.

Here's how the process works:
- The CloudWatch Rule names are defined under the `custom` section in serverless.yml
- Each function defines a `schedule` event under the `events` section of serverless.yml 
(This automatically initializes our default CloudWatch Rules on deployment - see the reviews or slackbot lambdas for examples)
- Whenever a setting is changed, the `main` lambda looks for an environment variable with the following format: `${settingName}_CLOUDWATCH_EVENT = ${nameOfCloudWatchEvent}`. If present, the named CloudWatch Rule is updated.

So, to add a new Lambda on an interval, 3 pieces of data are required:
- CloudWatch name in `serverless.yml -> custom`
- Default schedule event in `serverless.yml -> functions -> ${functionName} -> events`
- Env variable in `serverless.yml -> functions -> main -> environment`