### PR TITLE
Remove per-app-store scraper settings and switch to a single polling interval

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -72,7 +72,7 @@ functions:
       STAGE: ${self:provider.stage}
 
       # Flags for settings that require Lambda configuration updates
-      APPSTOREPOLLING_CLOUDWATCH_EVENT: ${self:custom.reviewsEventName}
+      POLLINGINTERVAL_CLOUDWATCH_EVENT: ${self:custom.reviewsEventName}
       POSTINGINTERVAL_CLOUDWATCH_EVENT: ${self:custom.slackbotEventName}
     events:
       - http:

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.html
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.html
@@ -48,23 +48,13 @@
 <form [formGroup]="scrapingForm" (ngSubmit)="onScrapingSubmit()">
   <div class="form-group mb-4">
       <div class="row">
-        <label for="app-store-polling">App Store Polling Interval</label>
+        <label for="polling-interval">Polling Interval</label>
         <div class="input-group mb-2">
-          <input type="text" class="form-control" id="app-store-polling" formControlName="appStorePolling" [class.is-invalid]="appStorePolling.invalid">
+          <input type="text" class="form-control" id="polling-interval" formControlName="pollingInterval" [class.is-invalid]="pollingInterval.invalid">
           <div class="input-group-append">
               <span class="input-group-text">minutes</span>
           </div>
         </div>
-      </div>
-  
-      <div class="row">
-        <label for="play-polling">Google Play Polling Interval</label>
-        <div class="input-group mb-2">
-            <input type="text" class="form-control" id="play-store-polling" formControlName="playStorePolling" [class.is-invalid]="playStorePolling.invalid">
-            <div class="input-group-append">
-                <span class="input-group-text">minutes</span>
-            </div>
-          </div>
       </div>
     
       <div class="row">

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.spec.ts
@@ -35,18 +35,13 @@ describe('SettingsComponent', () => {
 
   // Send inital setting values from the mock backend to populate the form
   function initializeSettings() {
-    const testAppStorePolling = '30';
-    const testPlayStorePolling = '25';
+    const testPollingInterval = '30';
 
     const testScrapingResponse: SettingResponse = {
       settings: [
         {
-          name: 'appStorePolling',
-          value: testAppStorePolling
-        },
-        {
-          name: 'playStorePolling',
-          value: testPlayStorePolling
+          name: 'pollingInterval',
+          value: testPollingInterval
         }
       ],
       message: null,
@@ -80,7 +75,7 @@ describe('SettingsComponent', () => {
 
     const reqs = httpMock.match(API_URL + 'settings/get');
     reqs.forEach((req) => {
-      if (req.request.body === JSON.stringify({names: ['appStorePolling', 'playStorePolling']})) {
+      if (req.request.body === JSON.stringify({names: ['pollingInterval']})) {
         req.flush(testScrapingResponse);
       } else {
         req.flush(testSlackResponse);
@@ -92,8 +87,7 @@ describe('SettingsComponent', () => {
 
     httpMock.verify();
 
-    expect(component.appStorePolling.value).toEqual(testAppStorePolling);
-    expect(component.playStorePolling.value).toEqual(testPlayStorePolling);
+    expect(component.pollingInterval.value).toEqual(testPollingInterval);
 
     expect(component.postingChannel.value).toEqual(testPostingChannel);
     expect(component.postingInterval.value).toEqual(testPostingInterval);
@@ -106,8 +100,7 @@ describe('SettingsComponent', () => {
   });
 
   it('should be valid when all fields are filled out', () => {
-    component.appStorePolling.setValue('30');
-    component.playStorePolling.setValue('30');
+    component.pollingInterval.setValue('30');
     component.scrapingForm.updateValueAndValidity();
     expect(component.scrapingForm.valid).toBeTruthy();
 
@@ -118,18 +111,12 @@ describe('SettingsComponent', () => {
   });
 
   it('should not be valid when fields are blank', () => {
-    component.appStorePolling.setValue('30');
-    component.scrapingForm.updateValueAndValidity();
-    expect(component.scrapingForm.valid).toBeFalsy();
-
-    component.appStorePolling.setValue('');
-    component.playStorePolling.setValue('30');
-    component.scrapingForm.updateValueAndValidity();
-    expect(component.scrapingForm.valid).toBeFalsy();
-
-    component.appStorePolling.setValue('30');
+    component.pollingInterval.setValue('30');
     component.scrapingForm.updateValueAndValidity();
     expect(component.scrapingForm.valid).toBeTruthy();
+
+    component.pollingInterval.setValue('');
+    expect(component.scrapingForm.valid).toBeFalsy();
 
     component.postingChannel.setValue('general');
     component.slackForm.updateValueAndValidity();
@@ -146,21 +133,11 @@ describe('SettingsComponent', () => {
   });
 
   it('should not be valid if fields are malformed', () => {
-    component.appStorePolling.setValue('abc');
-    component.playStorePolling.setValue('def');
+    component.pollingInterval.setValue('abc');
     component.scrapingForm.updateValueAndValidity();
     expect(component.scrapingForm.valid).toBeFalsy();
 
-    component.appStorePolling.setValue('30');
-    component.scrapingForm.updateValueAndValidity();
-    expect(component.scrapingForm.valid).toBeFalsy();
-
-    component.appStorePolling.setValue('abc');
-    component.playStorePolling.setValue('30');
-    component.scrapingForm.updateValueAndValidity();
-    expect(component.scrapingForm.valid).toBeFalsy();
-
-    component.appStorePolling.setValue('30');
+    component.pollingInterval.setValue('30');
     component.scrapingForm.updateValueAndValidity();
     expect(component.scrapingForm.valid).toBeTruthy();
 
@@ -206,8 +183,7 @@ describe('SettingsComponent', () => {
   it('should display a success message on save for a time interval', async() => {
     initializeSettings();
 
-    component.appStorePolling.setValue('30');
-    component.playStorePolling.setValue('30');
+    component.pollingInterval.setValue('30');
     component.scrapingForm.updateValueAndValidity();
     expect(component.scrapingForm.valid).toBeTruthy();
 
@@ -265,10 +241,8 @@ describe('SettingsComponent', () => {
   it('should update setting values on save', async () => {
     initializeSettings();
 
-    const updatedAppStorePolling = '25';
-    const updatedPlayStorePolling = '20';
-    component.appStorePolling.setValue(updatedAppStorePolling);
-    component.playStorePolling.setValue(updatedPlayStorePolling);
+    const updatedPollingInterval = '25';
+    component.pollingInterval.setValue(updatedPollingInterval);
     component.scrapingForm.updateValueAndValidity();
     expect(component.scrapingForm.valid).toBeTruthy();
 
@@ -286,12 +260,8 @@ describe('SettingsComponent', () => {
     const expectedScrapingRequest = {
       settings: [
         {
-          name: 'appStorePolling',
-          value: updatedAppStorePolling
-        },
-        {
-          name: 'playStorePolling',
-          value: updatedPlayStorePolling
+          name: 'pollingInterval',
+          value: updatedPollingInterval
         }
       ]
     };

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.ts
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.ts
@@ -19,9 +19,7 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
   private appListTimer: any;
 
   public scrapingForm: FormGroup;
-  public appStorePolling: AbstractControl;
-  public playStorePolling: AbstractControl;
-
+  public pollingInterval: AbstractControl;
   public scrapingFormError = '';
   public scrapingFormSuccess = false;
   private scrapingFormGetSubscription: Subscription;
@@ -42,11 +40,9 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit() {
     this.scrapingForm = this.fb.group({
-      'appStorePolling': ['', Validators.compose([Validators.required, Validators.pattern('[0-9]+')])],
-      'playStorePolling': ['', Validators.compose([Validators.required, Validators.pattern('[0-9]+')])]
+      'pollingInterval': ['', Validators.compose([Validators.required, Validators.pattern('[0-9]+')])]
     });
-    this.appStorePolling = this.scrapingForm.get('appStorePolling');
-    this.playStorePolling = this.scrapingForm.get('playStorePolling');
+    this.pollingInterval = this.scrapingForm.get('pollingInterval');
 
     this.slackForm = this.fb.group({
       'postingChannel': ['', Validators.compose([Validators.required, Validators.pattern('[a-zA-Z0-9-]+')])],
@@ -65,7 +61,7 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
         this.appList = response.appList;
       }
     });
-    this.scrapingFormGetSubscription = this.rest.getSettings(['appStorePolling', 'playStorePolling'])
+    this.scrapingFormGetSubscription = this.rest.getSettings(['pollingInterval'])
     .subscribe((response) => {
       if (response.status === 'ERROR') {
         this.scrapingFormError = response.message;
@@ -156,8 +152,7 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onScrapingSubmit() {
     this.scrapingFormSetSubscription = this.rest.setSettings([
-      { name: 'appStorePolling', value: this.appStorePolling.value },
-      { name: 'playStorePolling', value: this.playStorePolling.value }
+      { name: 'pollingInterval', value: this.pollingInterval.value }
     ]).subscribe((response) => {
       if (response.status === 'ERROR') {
         this.scrapingFormError = response.message;

--- a/frontend/sentiment-dashboard/src/environments/environment.ts
+++ b/frontend/sentiment-dashboard/src/environments/environment.ts
@@ -12,7 +12,7 @@ export const environment = {
       userPoolWebClientId: ''
     }
   },
-  backendUrl: 'https://3of8hfudu6.execute-api.us-east-2.amazonaws.com/yangmi13/'
+  backendUrl: 'https://rmafxge20k.execute-api.us-east-2.amazonaws.com/noah/'
 };
 
 /*


### PR DESCRIPTION
Removed our extra polling interval setting for the scraper, so we now only have one setting to adjust the scraping interval.