### PR TITLE
Fix/ui fixes

### DIFF
--- a/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.html
+++ b/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.html
@@ -10,9 +10,11 @@
 
 <div [class.row]="currentlyComparing">
   <div [class.col-md-6]="currentlyComparing">
+    <h2 class="mt-4" *ngIf="currentlyComparing">{{ form.getCompareTitle() }}</h2>
     <app-stats #stats1></app-stats>
   </div>
   <div *ngIf="currentlyComparing" class="col-md-6">
+      <h2 class="mt-4">{{ formCompare.getCompareTitle() }}</h2>
     <app-stats #stats2></app-stats>
   </div>
 </div>

--- a/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.spec.ts
@@ -52,6 +52,7 @@ describe('DashboardComponent', () => {
   it('successfully queries for updated stats', () => {
     // Send mock app list to initialize component
     const testApp: AppInfo = {
+      name: '',
       minDate: new Date('01-01-2018').toISOString(),
       maxDate: new Date('12-31-2018').toISOString(),
       versions: ['1.0.0', '2.0.0', '3.0.0']

--- a/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.spec.ts
@@ -11,6 +11,7 @@ describe('FormComponent', () => {
   let fixture: ComponentFixture<FormComponent>;
 
   const testApp: AppInfo = {
+    name: '',
     minDate: new Date('01-01-2018').toISOString(),
     maxDate: new Date('12-31-2018').toISOString(),
     versions: ['1.0.0', '2.0.0', '3.0.0']

--- a/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.ts
@@ -82,9 +82,7 @@ export class FormComponent implements OnInit {
   }
 
   public getCurrentValues(): StatsFilterValues | undefined {
-    if (this.statsFilterForm.invalid
-      || this.startDate === undefined
-      || this.endDate === undefined) {
+    if (!this.isValid()) {
       return undefined;
     }
 
@@ -98,12 +96,25 @@ export class FormComponent implements OnInit {
     return values;
   }
 
+  private isValid() {
+    return this.statsFilterForm.valid && this.startDate !== undefined && this.endDate !== undefined;
+  }
+
   public toggleComparison() {
     this.currentlyComparing = !this.currentlyComparing;
     this.compareText = this.currentlyComparing ? 'Stop Comparing' : 'Compare Apps';
     this.compare.emit(this.currentlyComparing);
   }
+
   public setAppList(apps: { [id: string]: AppInfo }) {
     this.appList = apps;
+  }
+
+  public getCompareTitle() {
+    if (!this.isValid()) {
+      return '---';
+    }
+
+    return this.selectedApp.name + ' - ' + this.version.value;
   }
 }

--- a/frontend/sentiment-dashboard/src/app/dashboard/stats/stats.component.html
+++ b/frontend/sentiment-dashboard/src/app/dashboard/stats/stats.component.html
@@ -4,7 +4,7 @@
 
 <div class="row mb-md-0 mt-2">
 <app-card title="Overall Sentiment">
-    <div class="m-auto" style="width: 500px;" *ngIf="pieChartData.length !== 0; else noData">
+    <div class="m-auto" style="width: 500px;" *ngIf="!pieChartIsEmpty(); else noData">
         <canvas baseChart
                 [data]="pieChartData"
                 [labels]="pieChartLabels"
@@ -39,7 +39,7 @@
 
 <div class="row">
 <app-card title="Sentiment Over Time">
-  <div *ngIf="lineChartData.length !== 0; else noData">
+  <div *ngIf="!lineChartIsEmpty(); else noData">
     <canvas baseChart
     [datasets]="lineChartData"
     [labels]="lineChartLabels"

--- a/frontend/sentiment-dashboard/src/app/dashboard/stats/stats.component.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/stats/stats.component.ts
@@ -72,6 +72,9 @@ export class StatsComponent implements OnInit {
     this.lineChartData = [
       { data: stats['sentimentOverTime']['data'], label: '% Negative Reviews'},
     ];
+
+    console.log(this.pieChartData);
+    console.log(this.lineChartData);
   }
 
   public getPercentTooltip() {
@@ -88,5 +91,17 @@ export class StatsComponent implements OnInit {
       const tooltipData = allData[tooltipItem.index];
       return  Math.round(tooltipData) + '%' + ' of ' + this.reviewTotals[tooltipItem.index] + ' reviews';
     };
+  }
+
+  public pieChartIsEmpty() {
+    // If no data are present, or all data are 0, then chart is empty
+    return this.pieChartData.length === 0
+      || this.pieChartData.filter((element) => element !== 0).length === 0;
+  }
+
+  public lineChartIsEmpty() {
+    // If no data are present, or all data are null, then chart is empty
+    return this.lineChartData.length === 0
+      || this.lineChartData[0].data.filter((element) => element !== null).length === 0;
   }
 }

--- a/frontend/sentiment-dashboard/src/app/rest/domain.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/domain.ts
@@ -40,6 +40,7 @@ export interface App {
 }
 
 export interface AppInfo {
+  name: string;
   minDate: string;
   maxDate: string;
   versions: string[];

--- a/frontend/sentiment-dashboard/src/app/shared/nav/nav.component.html
+++ b/frontend/sentiment-dashboard/src/app/shared/nav/nav.component.html
@@ -5,7 +5,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarText" [collapse]="isCollapsed">
       <ul class="navbar-nav ml-auto">
-        <li class="nav-item active">
+        <li class="nav-item">
           <a class="nav-link" routerLink="/dashboard" routerLinkActive="active">Home</a>
         </li>
         <li class="nav-item">

--- a/frontend/sentiment-dashboard/src/app/shared/nav/nav.component.scss
+++ b/frontend/sentiment-dashboard/src/app/shared/nav/nav.component.scss
@@ -1,0 +1,3 @@
+.active {
+  color: black;
+}


### PR DESCRIPTION
Fixes for some of the UI papercuts we've been noticing, including: highlighting the active link in the nav, display titles for the two stat columns when comparing apps, and correctly displaying "no data" messages. These changes depend on #47, so should be merged after that PR.