### PR TITLE
Feature/support itunes numerical ids

### DIFF
--- a/backend/main/src/main/java/sentiment/apps/AppsResponse.java
+++ b/backend/main/src/main/java/sentiment/apps/AppsResponse.java
@@ -1,7 +1,6 @@
 package sentiment.apps;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 import sentiment.Response;
 

--- a/backend/main/src/main/java/sentiment/apps/AppsResponse.java
+++ b/backend/main/src/main/java/sentiment/apps/AppsResponse.java
@@ -36,9 +36,11 @@ public class AppsResponse extends Response {
 
     data.put("status", status);
     if (status == Status.SUCCESS) {
+      Map<String, AppInfo> appList = new HashMap<String, AppInfo>();
       for (AppInfo app : apps) {
-        data.put(app.getAppIdStore(), app);
+        appList.put(app.getAppIdStore(), app);
       }
+      data.put("apps", appList);
     } else {
       data.put("message", message);
     }

--- a/backend/reviews/handler.js
+++ b/backend/reviews/handler.js
@@ -146,7 +146,7 @@ async function getReviews(appList) {
 
 /**
  * Pull all pages of an app's reviews from the given store
- * @param appId The app ID string to use (NOT a numerical App Store id)
+ * @param appId The app ID string to use (either a numerical App Store ID or a GPlay package ID)
  * @param scraper The scraping module to use 
  * @param store The app store name
  */
@@ -162,8 +162,9 @@ async function scrape(appId, scraper, store) {
         throttle: 1
       }));
     } else if (store === 'App Store') {
+      console.log(`Scraping app store ${appId}`);
       promises.push(scraper.reviews({
-        appId: appId,
+        id: appId,
         page: i + 1
       }));
     }
@@ -179,9 +180,16 @@ async function scrape(appId, scraper, store) {
     throw error;
   }
 
-  let appInfo = await scraper.app({
-    appId: appId
-  });
+  let appInfo;
+  if (store === 'Google Play') {
+    appInfo = await scraper.app({
+      appId: appId
+    });
+  } else if (store === 'App Store') {
+    appInfo = await scraper.app({
+      id: appId
+    });
+  }
   let reviews = [].concat(...allPages).map(await convertReviewToDynamoRepresentation(appId, store, appInfo.version));
 
   return reviews;

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix=

--- a/frontend/sentiment-dashboard/package-lock.json
+++ b/frontend/sentiment-dashboard/package-lock.json
@@ -6815,9 +6815,9 @@
       }
     },
     "ngx-bootstrap": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-3.1.1.tgz",
-      "integrity": "sha512-LY9ZnzkTA67MOUcQoA3i6JM4TGPCDUnjUMZctSesic0E9617bPrKDnb2VPOEU4VFTXWMhu6xbPcXsvLrc6m/lg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-3.0.1.tgz",
+      "integrity": "sha512-ni91yYtn8ldgf/pxrlwl9lkVcLURGzopSpJnEbbgG1v1EZWTobI8y7J3mx4Kxptkn0EeiQwnLel67G7XJSox4A=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/frontend/sentiment-dashboard/package.json
+++ b/frontend/sentiment-dashboard/package.json
@@ -27,7 +27,7 @@
     "chart.js": "^2.7.2",
     "core-js": "^2.5.4",
     "ng2-charts": "^1.6.0",
-    "ngx-bootstrap": "^3.1.1",
+    "ngx-bootstrap": "~3.0.1",
     "node-sass": "^4.9.3",
     "rxjs": "^6.3.3",
     "zone.js": "~0.8.26"

--- a/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.spec.ts
@@ -9,9 +9,9 @@ import { StatsComponent } from './stats/stats.component';
 import { AuthService } from '../auth/auth.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { environment } from 'src/environments/environment';
-import { StatResponse, Keyword, AppInfo } from '../rest/domain';
+import { StatResponse, FilterInfo } from '../rest/domain';
 import { BsDatepickerModule, BsDaterangepickerConfig, BsLocaleService } from 'ngx-bootstrap/datepicker';
-import { ComponentLoaderFactory } from 'ngx-bootstrap/loader';
+import { ComponentLoaderFactory } from 'ngx-bootstrap';
 import { PositioningService } from 'ngx-bootstrap/positioning';
 
 describe('DashboardComponent', () => {
@@ -51,14 +51,14 @@ describe('DashboardComponent', () => {
 
   it('successfully queries for updated stats', () => {
     // Send mock app list to initialize component
-    const testApp: AppInfo = {
+    const testApp: FilterInfo = {
       name: '',
       minDate: new Date('01-01-2018').toISOString(),
       maxDate: new Date('12-31-2018').toISOString(),
       versions: ['1.0.0', '2.0.0', '3.0.0']
     };
 
-    const testAppList: { [id: string]: AppInfo } = {
+    const testAppList: { [id: string]: FilterInfo } = {
       'testApp': testApp
     };
     const appsReq = httpMock.expectOne(API_URL + 'apps');

--- a/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
-import { StatRequest, AppInfo } from '../rest/domain';
+import { StatRequest, FilterListResponse } from '../rest/domain';
 import { Subscription, timer } from 'rxjs';
 import { FormComponent, StatsFilterValues } from './form/form.component';
 import { StatsComponent } from './stats/stats.component';
@@ -26,9 +26,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   constructor(private rest: RestService) { }
 
   ngOnInit() {
-    this.appsSubscription = this.rest.getFilterApps().subscribe((apps: { [id: string]: AppInfo }) => {
-      this.form.setAppList(apps);
-      this.formCompare.setAppList(apps);
+    this.appsSubscription = this.rest.getFilterList().subscribe((response: FilterListResponse) => {
+      this.form.setAppList(response.apps);
+      this.formCompare.setAppList(response.apps);
     });
 
     this.autoUpdate = timer(0, 100000).subscribe(() => {

--- a/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.spec.ts
@@ -1,23 +1,23 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormComponent, StatsFilterValues } from './form.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { AppInfo } from 'src/app/rest/domain';
 import { BsDatepickerModule, BsDaterangepickerConfig, BsLocaleService } from 'ngx-bootstrap/datepicker';
-import { ComponentLoaderFactory } from 'ngx-bootstrap/loader';
+import { ComponentLoaderFactory } from 'ngx-bootstrap';
 import { PositioningService } from 'ngx-bootstrap/positioning';
+import { FilterInfo } from 'src/app/rest/domain';
 
 describe('FormComponent', () => {
   let component: FormComponent;
   let fixture: ComponentFixture<FormComponent>;
 
-  const testApp: AppInfo = {
+  const testApp: FilterInfo = {
     name: '',
     minDate: new Date('01-01-2018').toISOString(),
     maxDate: new Date('12-31-2018').toISOString(),
     versions: ['1.0.0', '2.0.0', '3.0.0']
   };
 
-  const testAppList: { [id: string]: AppInfo } = {
+  const testAppList: { [id: string]: FilterInfo } = {
     'testApp': testApp
   };
 

--- a/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/form/form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormGroup, AbstractControl, Validators, FormBuilder } from '@angular/forms';
-import { AppInfo } from 'src/app/rest/domain';
+import { FilterInfo } from 'src/app/rest/domain';
 
 
 export interface StatsFilterValues {
@@ -25,8 +25,8 @@ export class FormComponent implements OnInit {
 
   @Output() filterChange = new EventEmitter<StatsFilterValues>();
 
-  public appList: { [id: string]: AppInfo } = {};
-  public selectedApp?: AppInfo;
+  public appList: { [id: string]: FilterInfo } = {};
+  public selectedApp?: FilterInfo;
   public minDate?: Date;
   public maxDate?: Date;
 
@@ -106,7 +106,7 @@ export class FormComponent implements OnInit {
     this.compare.emit(this.currentlyComparing);
   }
 
-  public setAppList(apps: { [id: string]: AppInfo }) {
+  public setAppList(apps: { [id: string]: FilterInfo }) {
     this.appList = apps;
   }
 

--- a/frontend/sentiment-dashboard/src/app/dashboard/stats/stats.component.ts
+++ b/frontend/sentiment-dashboard/src/app/dashboard/stats/stats.component.ts
@@ -72,9 +72,6 @@ export class StatsComponent implements OnInit {
     this.lineChartData = [
       { data: stats['sentimentOverTime']['data'], label: '% Negative Reviews'},
     ];
-
-    console.log(this.pieChartData);
-    console.log(this.lineChartData);
   }
 
   public getPercentTooltip() {

--- a/frontend/sentiment-dashboard/src/app/rest/domain.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/domain.ts
@@ -39,11 +39,17 @@ export interface App {
   appId: string;
 }
 
-export interface AppInfo {
+export interface FilterInfo {
   name: string;
   minDate: string;
   maxDate: string;
   versions: string[];
+}
+
+export interface FilterListResponse {
+  status: string,
+  message?: string,
+  apps?: {[id: string]: FilterInfo}
 }
 
 export interface Keyword {

--- a/frontend/sentiment-dashboard/src/app/rest/domain.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/domain.ts
@@ -47,9 +47,9 @@ export interface FilterInfo {
 }
 
 export interface FilterListResponse {
-  status: string,
-  message?: string,
-  apps?: {[id: string]: FilterInfo}
+  status: string;
+  message?: string;
+  apps?: {[id: string]: FilterInfo};
 }
 
 export interface Keyword {

--- a/frontend/sentiment-dashboard/src/app/rest/rest.service.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/rest.service.spec.ts
@@ -25,17 +25,18 @@ describe('RestService', () => {
   it('should successfully query the backend for the filter app list',
     inject([HttpTestingController, RestService], async (httpMock: HttpTestingController, service: RestService) => {
     const testResponse = {
-      'com.ford.fordpass*Google Play': {
-        name: 'FordPass (Google Play)',
-        minDate: '2018-06-28',
-        maxDate: '2018-10-14',
-        versions: [
-            '2.4.1'
-        ]
+      status: 'SUCCESS',
+      apps: {
+        'com.ford.fordpass*Google Play': {
+          name: 'FordPass (Google Play)',
+          minDate: '2018-06-28',
+          maxDate: '2018-10-14',
+          versions: [ '2.4.1' ]
+        }
       }
     };
 
-    service.getFilterApps().subscribe((response) => {
+    service.getFilterList().subscribe((response) => {
       expect(response).toEqual(testResponse);
     });
     const req = httpMock.expectOne(API_URL + 'apps');

--- a/frontend/sentiment-dashboard/src/app/rest/rest.service.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/rest.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {environment} from '../../environments/environment';
-import { AppInfo, StatResponse, StatRequest, Setting, SettingResponse, App, AppListResponse } from './domain';
+import { StatResponse, StatRequest, Setting, SettingResponse, App, AppListResponse, FilterListResponse } from './domain';
 import { AuthService } from '../auth/auth.service';
 
 @Injectable({
@@ -22,11 +22,11 @@ export class RestService {
     });
   }
 
-  getFilterApps(): Observable<{ [id: string]: AppInfo }> {
+  getFilterList(): Observable<FilterListResponse> {
     const options = {
       headers: new HttpHeaders({'Content-Type' : 'application/json'})
     };
-    return this.http.get<{ [id: string]: AppInfo }>(this.API_URL + 'apps', options);
+    return this.http.get<FilterListResponse>(this.API_URL + 'apps', options);
   }
 
   getSentimentStats(appIdStore: string, version: string, startDate: Date, endDate: Date, stats: StatRequest[]) {

--- a/frontend/sentiment-dashboard/src/app/settings/add-app/add-app.component.html
+++ b/frontend/sentiment-dashboard/src/app/settings/add-app/add-app.component.html
@@ -10,7 +10,7 @@
     <input type="text" class="form-control" id="app-name" formControlName="appName" [class.is-invalid]="appName.invalid">
   
     <label for="app-store" class="mr-2">Store</label>
-    <select class="form-control" id="app-store" formControlName="appStore" [class.is-invalid]="appStore.invalid">
+    <select class="form-control" id="app-store" formControlName="appStore" [class.is-invalid]="appStore.invalid" (change)="onStoreChange()">
       <option>App Store</option>
       <option>Google Play</option>
     </select>

--- a/frontend/sentiment-dashboard/src/app/settings/add-app/add-app.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/settings/add-app/add-app.component.spec.ts
@@ -60,6 +60,7 @@ describe('AddAppComponent', () => {
   it('should not submit if the appId format is invalid', () => {
     component.appName.setValue('Test Name');
     component.appStore.setValue('Google Play');
+    component.onStoreChange();
     component.appId.setValue('com.ford.test&');
     component.addAppForm.updateValueAndValidity();
 
@@ -69,5 +70,19 @@ describe('AddAppComponent', () => {
     component.addAppForm.updateValueAndValidity();
 
     expect(component.addAppForm.valid).toBeTruthy();
+
+    component.appStore.setValue('App Store');
+    component.onStoreChange();
+    component.appId.setValue('com.ford.test');
+    component.addAppForm.updateValueAndValidity();
+
+    expect(component.addAppForm.valid).toBeFalsy();
+
+    component.appId.setValue('12345678');
+    component.addAppForm.updateValueAndValidity();
+
+    expect(component.addAppForm.valid).toBeTruthy();
+
+
   });
 });

--- a/frontend/sentiment-dashboard/src/app/settings/add-app/add-app.component.ts
+++ b/frontend/sentiment-dashboard/src/app/settings/add-app/add-app.component.ts
@@ -22,7 +22,7 @@ export class AddAppComponent implements OnInit {
     this.addAppForm = this.fb.group({
       'appName': ['', Validators.required],
       'appStore': ['', Validators.required],
-      'appId': ['', Validators.compose([Validators.required, Validators.pattern('[0-9a-zA-Z_.]+')])]
+      'appId': ['', Validators.compose([Validators.required])]
     });
     this.appName = this.addAppForm.get('appName');
     this.appStore = this.addAppForm.get('appStore');
@@ -36,5 +36,20 @@ export class AddAppComponent implements OnInit {
       appId: this.appId.value
     });
     this.bsModalRef.hide();
+  }
+
+  onStoreChange() {
+    const appStorePattern = '[0-9]+';
+    const googlePlayPattern = '[0-9a-zA-Z_.]+';
+
+    const store = this.appStore.value;
+
+    if (store === 'App Store') {
+      this.appId.setValidators([Validators.required, Validators.pattern(appStorePattern)]);
+    } else if (store === 'Google Play') {
+      this.appId.setValidators([Validators.required, Validators.pattern(googlePlayPattern)]);
+    }
+
+    this.appId.updateValueAndValidity();
   }
 }

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.spec.ts
@@ -8,7 +8,7 @@ import { environment } from 'src/environments/environment';
 import { SettingResponse, App, AppListResponse } from '../rest/domain';
 import { AuthService } from '../auth/auth.service';
 import { ModalModule, BsModalService } from 'ngx-bootstrap/modal';
-import { ComponentLoaderFactory } from 'ngx-bootstrap/loader';
+import { ComponentLoaderFactory } from 'ngx-bootstrap';
 import { PositioningService } from 'ngx-bootstrap/positioning';
 
 describe('SettingsComponent', () => {


### PR DESCRIPTION
Use iTunes numerical ids for App Store apps because they're easier to find and use (right in the App Store URL). Updated the scraper's request format to use these IDs and changed our form validation to check for correct ID format as well.