### PR TITLE
Settings page restriction

### DIFF
--- a/frontend/sentiment-dashboard/src/app/app-routing.module.ts
+++ b/frontend/sentiment-dashboard/src/app/app-routing.module.ts
@@ -4,6 +4,8 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { SettingsComponent } from './settings/settings.component';
 import { LoginComponent } from './login/login.component';
 import { AuthGuardService } from './auth/auth.guard';
+import { AdminGuard } from './auth/admin.guard';
+import { AuthService } from './auth/auth.service';
 
 const routes: Routes = [
   { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
@@ -15,7 +17,7 @@ const routes: Routes = [
   {
     path: 'settings',
     component: SettingsComponent,
-    canActivate: [AuthGuardService]
+    canActivate: [AuthGuardService, AdminGuard]
   },
   { path: 'login', component: LoginComponent }
 ];

--- a/frontend/sentiment-dashboard/src/app/auth/admin.guard.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/auth/admin.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { AdminGuard } from './admin.guard';
+
+describe('AdminGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AdminGuard]
+    });
+  });
+
+  it('should ...', inject([AdminGuard], (guard: AdminGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/frontend/sentiment-dashboard/src/app/auth/admin.guard.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/auth/admin.guard.spec.ts
@@ -1,11 +1,14 @@
 import { TestBed, async, inject } from '@angular/core/testing';
 
 import { AdminGuard } from './admin.guard';
+import { AuthService } from './auth.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('AdminGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [AdminGuard]
+      imports: [RouterTestingModule],
+      providers: [AdminGuard, AuthService]
     });
   });
 

--- a/frontend/sentiment-dashboard/src/app/auth/admin.guard.ts
+++ b/frontend/sentiment-dashboard/src/app/auth/admin.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable, OnInit } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+import { tap } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminGuard implements CanActivate {
+  constructor(
+      public auth: AuthService,
+      public router: Router
+    ) {
+    }
+
+    canActivate(): Observable<boolean> {
+      return this.auth.isAdmin();
+    }
+}

--- a/frontend/sentiment-dashboard/src/app/auth/auth.service.ts
+++ b/frontend/sentiment-dashboard/src/app/auth/auth.service.ts
@@ -63,10 +63,8 @@ export class AuthService {
         const userGroups = session.getIdToken().decodePayload()['cognito:groups'];
         if (userGroups !== undefined) {
           const found = userGroups.includes('admin');
-          if (userGroups.includes('admin')) {
+          if (found) {
             return true;
-          } else {
-            return false;
           }
         }
         return false;

--- a/frontend/sentiment-dashboard/src/app/auth/auth.service.ts
+++ b/frontend/sentiment-dashboard/src/app/auth/auth.service.ts
@@ -56,4 +56,21 @@ export class AuthService {
       })
     );
   }
+
+  public isAdmin(): Observable<boolean> {
+    return from(Auth.currentSession()).pipe(
+      map(session => {
+        const userGroups = session.getIdToken().decodePayload()['cognito:groups'];
+        if (userGroups !== undefined) {
+          const found = userGroups.includes('admin');
+          if (userGroups.includes('admin')) {
+            return true;
+          } else {
+            return false;
+          }
+        }
+        return false;
+      })
+    );
+  }
 }


### PR DESCRIPTION
Restricts settings page to admins only (determined by if they are in the admin group on cognito). The settings page button still shows on the navbar if the user isn't an admin, but that should be a quick change. 