### PR TITLE
Feature/keywords ignore

### DIFF
--- a/backend/main/src/main/java/sentiment/Handler.java
+++ b/backend/main/src/main/java/sentiment/Handler.java
@@ -7,6 +7,7 @@ import org.springframework.cloud.function.adapter.aws.SpringBootApiGatewayReques
 import sentiment.apps.AppsRequest;
 import sentiment.settings.AppListRequest;
 import sentiment.settings.GetSettingsRequest;
+import sentiment.settings.IgnoreListRequest;
 import sentiment.settings.SetSettingsRequest;
 import sentiment.stats.StatsRequest;
 
@@ -27,6 +28,8 @@ public class Handler extends SpringBootApiGatewayRequestHandler {
         return AppsRequest.class;
       case "/settings/apps":
         return AppListRequest.class;
+      case "/settings/keywords":
+        return IgnoreListRequest.class;
       case "/settings/get":
         return GetSettingsRequest.class;
       case "/settings/set":

--- a/backend/main/src/main/java/sentiment/Response.java
+++ b/backend/main/src/main/java/sentiment/Response.java
@@ -2,17 +2,48 @@ package sentiment;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Response format for sentiment API.
  */
-public abstract class Response {
+public class Response {
   protected enum Status {
     SUCCESS,
     ERROR;
   }
+
+  private Status status = Status.SUCCESS;
+  private String message = "";
   
+  /**
+   * Return a map of the JSON keys and values for this object.
+   */
   @JsonAnyGetter
-  public abstract Map<String, Object> getData();
+  public Map<String, Object> getData() {
+    Map<String, Object> data = new HashMap<String, Object>();
+    data.put("status", this.status);
+
+    if (this.status == Status.ERROR) {
+      data.put("message", this.message);
+    }
+
+    return data;
+  }
+
+  public Response() { }
+
+  public Response(String message) {
+    this.status = Status.ERROR;
+    this.message = message;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public String getMessage() {
+    return message;
+  }
 }

--- a/backend/main/src/main/java/sentiment/apps/AppsResponse.java
+++ b/backend/main/src/main/java/sentiment/apps/AppsResponse.java
@@ -13,17 +13,12 @@ import java.util.Map;
 public class AppsResponse extends Response {
   private AppInfo[] apps;
 
-  private Status status;
-  private String message;
-
   public AppsResponse(AppInfo[] apps) {
-    this.status = Status.SUCCESS;
     this.apps = apps;
   }
 
   public AppsResponse(String message) {
-    this.status = Status.ERROR;
-    this.message = message;
+    super(message);
   }
 
   /**
@@ -31,20 +26,15 @@ public class AppsResponse extends Response {
    */
   @JsonAnyGetter
   public Map<String, Object> getData() {
-    Map<String, Object> data = new HashMap<String, Object>();
+    Map<String, Object> data = super.getData();
 
-    data.put("status", status);
-    if (status == Status.SUCCESS) {
+    if (this.getStatus() == Status.SUCCESS) {
       Map<String, AppInfo> appList = new HashMap<String, AppInfo>();
       for (AppInfo app : apps) {
         appList.put(app.getAppIdStore(), app);
       }
       data.put("apps", appList);
-    } else {
-      data.put("message", message);
     }
-
-    System.out.println(data.toString());
 
     return data;
   }

--- a/backend/main/src/main/java/sentiment/settings/AppListRequest.java
+++ b/backend/main/src/main/java/sentiment/settings/AppListRequest.java
@@ -5,16 +5,9 @@ import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.lambda.model.InvocationType;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
-import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
-import com.amazonaws.services.simplesystemsmanagement.model.ParameterType;
-import com.amazonaws.services.simplesystemsmanagement.model.PutParameterRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import sentiment.Request;
 import sentiment.Response;
 
 import java.util.Arrays;

--- a/backend/main/src/main/java/sentiment/settings/AppListResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/AppListResponse.java
@@ -13,8 +13,6 @@ import java.util.Map;
  */
 public class AppListResponse extends Response {
   private App[] appList;
-  private Status status;
-  private String message;
 
   /**
    * Create an AppListResponse (success condition).
@@ -22,8 +20,6 @@ public class AppListResponse extends Response {
    */
   public AppListResponse(App[] appList) {
     this.appList = appList;
-    this.status = Status.SUCCESS;
-    this.message = "";
   }
 
   /**
@@ -31,9 +27,7 @@ public class AppListResponse extends Response {
    * @param message The error message.
    */
   public AppListResponse(String message) {
-    this.appList = null;
-    this.status = Status.ERROR;
-    this.message = message;
+    super(message);
   }
 
   /**
@@ -41,13 +35,10 @@ public class AppListResponse extends Response {
    */
   @JsonAnyGetter
   public Map<String, Object> getData() {
-    Map<String, Object> data = new HashMap<String, Object>();
+    Map<String, Object> data = super.getData();
 
-    data.put("status", this.status);
-    if (this.appList != null) {
+    if (this.getStatus() == Status.SUCCESS) {
       data.put("appList", this.appList);
-    } else {
-      data.put("message", this.message);
     }
 
     return data;

--- a/backend/main/src/main/java/sentiment/settings/Constants.java
+++ b/backend/main/src/main/java/sentiment/settings/Constants.java
@@ -2,7 +2,8 @@ package sentiment.settings;
 
 public final class Constants {
 
-  private static final String STAGE = System.getenv("STAGE");
+  public static final String STAGE = System.getenv("STAGE");
+  public static final String REGION = System.getenv("DEPLOY_REGION");
 
   public static final String APPLIST_SSM_PARAM = "appList-" + STAGE;
 

--- a/backend/main/src/main/java/sentiment/settings/Constants.java
+++ b/backend/main/src/main/java/sentiment/settings/Constants.java
@@ -6,6 +6,7 @@ public final class Constants {
   public static final String REGION = System.getenv("DEPLOY_REGION");
 
   public static final String APPLIST_SSM_PARAM = "appList-" + STAGE;
+  public static final String IGNORELIST_SSM_PARAM = "ignoreList-" + STAGE;
 
   /**
    * Add the current stage to the requested parameter name.

--- a/backend/main/src/main/java/sentiment/settings/GetSettingsResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/GetSettingsResponse.java
@@ -11,9 +11,6 @@ import java.util.Map;
  */
 public class GetSettingsResponse extends Response {
 
-  private Status status;
-  private String message;
-
   private Setting[] settings;
 
   /**
@@ -22,20 +19,14 @@ public class GetSettingsResponse extends Response {
    */
   public GetSettingsResponse(Setting[] settings) {
     this.settings = settings;
-
-    this.status = Status.SUCCESS;
-    this.message = "";
   }
 
   /**
    * Return an error in response to a get settings request.
-   * @param error The error message to send.
+   * @param message The error message to send.
    */
-  public GetSettingsResponse(String error) {
-    this.settings = null;
-
-    this.status = Status.ERROR;
-    this.message = error;
+  public GetSettingsResponse(String message) {
+    super(message);
   }
 
   /**
@@ -43,13 +34,10 @@ public class GetSettingsResponse extends Response {
    */
   @JsonAnyGetter
   public Map<String, Object> getData() {
-    Map<String, Object> data = new HashMap<String, Object>();
+    Map<String, Object> data = super.getData();
 
-    data.put("status", this.status);
-    if (this.settings != null) {
+    if (this.getStatus() == Status.SUCCESS) {
       data.put("settings", this.settings);
-    } else {
-      data.put("message", this.message);
     }
 
     return data;

--- a/backend/main/src/main/java/sentiment/settings/IgnoreListRequest.java
+++ b/backend/main/src/main/java/sentiment/settings/IgnoreListRequest.java
@@ -1,0 +1,113 @@
+package sentiment.settings;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+
+
+/**
+ * A query to get or update the list of keywords to ignore.
+ */
+public class IgnoreListRequest extends ListRequest<String> {
+
+  /**
+   * Creatse a new IgnoreListRequest.
+   * @param command The command to perform - get, add, or delete words
+   * @param keyword The keyword to add or delete, if appropriate
+   */
+  @JsonCreator
+  public IgnoreListRequest(
+      @JsonProperty("command") String command, 
+      @JsonProperty("keyword") String keyword) {
+    super(command, Constants.IGNORELIST_SSM_PARAM, keyword);
+  }
+
+  /**
+   * Convert SSM's JSON representation to a POJO representation
+   * @param json The JSON list.
+   * @return The list as an array of Java objects
+   */
+  protected String[] deserializeList(String json) throws Exception {
+    return new ObjectMapper().readValue(json, String[].class);
+  }
+
+  /**
+   * Add an app to the SSM list.
+   * @param client The SSM client to use.
+   * @param ignoreList The existing word list.
+   * @param keyword The word to add.
+   * @return An IgnoreListResponse with an error message or the updated list.
+   */
+  protected IgnoreListResponse add(
+      AWSSimpleSystemsManagement client, 
+      String[] ignoreList, 
+      String keyword) {
+    for (String existingKeyword : ignoreList) {
+      if (existingKeyword.equals(keyword)) {
+        return new IgnoreListResponse(
+          "Keyword " + keyword + " already exists in the list.");
+      }
+    }
+
+    String[] newList = Arrays.copyOf(ignoreList, ignoreList.length + 1);
+    newList[newList.length - 1] = keyword;
+
+    String message = writeList(client, newList);
+
+    if (!message.isEmpty()) {
+      return new IgnoreListResponse(message);
+    }
+
+    return new IgnoreListResponse(newList);
+  }
+
+  /**
+   * Delete a keyword from the SSM list.
+   * @param client The SSM client to use.
+   * @param ignoreList The existing keyword list.
+   * @param keyword The keyword to delete.
+   * @return An IgnoreListResponse with an error message or the updated list.
+   */
+  protected IgnoreListResponse delete(
+      AWSSimpleSystemsManagement client, 
+      String[] ignoreList, 
+      String keyword) {
+    String[] newList = new String[ignoreList.length - 1];
+    int idx = 0;
+
+    boolean present = false;
+    for (String existingKeyword : ignoreList) {
+      if (existingKeyword.equals(keyword)) {
+        present = true;
+      } else if (idx < ignoreList.length - 1) {
+        newList[idx] = existingKeyword;
+        idx++;
+      }
+    }
+
+    if (!present) {
+      return new IgnoreListResponse("No keyword " + keyword + " present in list.");
+    }
+
+    String message = writeList(client, newList);
+    if (!message.isEmpty()) {
+      return new IgnoreListResponse(message);
+    }
+
+    return new IgnoreListResponse(newList);
+  }
+
+  /**
+   * Format the current list in a Response object.
+   * @param list The list to format
+   * @return A Response with the list.
+   */
+  protected IgnoreListResponse get(String[] list) {
+    return new IgnoreListResponse(list);
+  }
+
+
+}

--- a/backend/main/src/main/java/sentiment/settings/IgnoreListResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/IgnoreListResponse.java
@@ -1,0 +1,46 @@
+package sentiment.settings;
+
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+
+import sentiment.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A response to a request to get or update the keyword ignore list.
+ */
+public class IgnoreListResponse extends Response {
+  private String[] ignoreList;
+
+  /**
+   * Create an IgnoreListResponse (success condition).
+   * @param ignoreList The updated list of keywords to ignore.
+   */
+  public IgnoreListResponse(String[] ignoreList) {
+    this.ignoreList = ignoreList;
+  }
+
+  /**
+   * Create an IgnoreListResponse (error condition).
+   * @param message The error message.
+   */
+  public IgnoreListResponse(String message) {
+    super(message);
+  }
+
+  /**
+   * Return a map of JSON keys and values for this object.
+   */
+  @JsonAnyGetter
+  public Map<String, Object> getData() {
+    Map<String, Object> data = super.getData();
+
+    if (this.getStatus() == Status.SUCCESS) {
+      data.put("ignoreList", this.ignoreList);
+    }
+
+    return data;
+  }
+}

--- a/backend/main/src/main/java/sentiment/settings/ListRequest.java
+++ b/backend/main/src/main/java/sentiment/settings/ListRequest.java
@@ -25,22 +25,23 @@ public abstract class ListRequest<T> extends Request {
   }
 
   private Command command;
-  private String settingName;
+  private String paramName;
   private T item;
   private T[] list;
 
   /**
    * Creatse a new ListRequest.
    * @param command The command to perform - get, add, or delete
-   * @param settingName The name of the SSM value to set.
+   * @param paramName The name of the SSM value to set.
    * @param item The item to add or delete, if appropriate
    */
-  public ListRequest(String command, String settingName, T item) {
+  public ListRequest(String command, String paramName, T item) {
     try {
       this.command = Command.valueOf(command);
     } catch (Exception exp) {
       this.command = null; // We'll return an error during processing
     }
+    this.paramName = paramName;
     this.item = item;
   }
 
@@ -109,7 +110,7 @@ public abstract class ListRequest<T> extends Request {
     GetParameterResult result = null;
     String value = null;
     try {
-      result = client.getParameter(new GetParameterRequest().withName(settingName));
+      result = client.getParameter(new GetParameterRequest().withName(paramName));
       value = result.getParameter().getValue();
     } catch (ParameterNotFoundException exp) {
       value = "[]";
@@ -140,7 +141,7 @@ public abstract class ListRequest<T> extends Request {
 
     try {
       client.putParameter(new PutParameterRequest()
-          .withName(settingName)
+          .withName(paramName)
           .withValue(json)
           .withType(ParameterType.String)
           .withOverwrite(true));

--- a/backend/main/src/main/java/sentiment/settings/ListRequest.java
+++ b/backend/main/src/main/java/sentiment/settings/ListRequest.java
@@ -1,0 +1,157 @@
+package sentiment.settings;
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
+import com.amazonaws.services.simplesystemsmanagement.model.ParameterType;
+import com.amazonaws.services.simplesystemsmanagement.model.PutParameterRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import sentiment.Request;
+import sentiment.Response;
+
+
+/**
+ * A query to get or update a list-based setting.
+ */
+public abstract class ListRequest<T> extends Request {
+
+  protected enum Command {
+    ADD,
+    DELETE,
+    GET;
+  }
+
+  private Command command;
+  private String settingName;
+  private T item;
+  private T[] list;
+
+  /**
+   * Creatse a new ListRequest.
+   * @param command The command to perform - get, add, or delete
+   * @param settingName The name of the SSM value to set.
+   * @param item The item to add or delete, if appropriate
+   */
+  public ListRequest(String command, String settingName, T item) {
+    try {
+      this.command = Command.valueOf(command);
+    } catch (Exception exp) {
+      this.command = null; // We'll return an error during processing
+    }
+    this.item = item;
+  }
+
+  /**
+   * Process the data for this request and return a response.
+   */
+  public Response process() {
+    AWSSimpleSystemsManagement client = AWSSimpleSystemsManagementClientBuilder.defaultClient();
+    String message = getList(client);
+
+    if (!message.isEmpty()) {
+      return new Response(message);
+    }
+
+    switch (this.command) {
+      case ADD:
+        return add(client, this.list, this.item);
+      case DELETE:
+        return delete(client, this.list, this.item);
+      case GET:
+        return get(this.list);
+      default:
+        return new Response("Invalid command " + this.command);
+    }
+  }
+
+  /**
+   * Convert SSM's JSON representation to a POJO representation
+   * @param json The JSON list.
+   * @return The list as an array of Java objects
+   */
+  protected abstract T[] deserializeList(String json) throws Exception;
+
+  /**
+   * Add an item to the SSM list.
+   * @param client The SSM client to use.
+   * @param list The existing list.
+   * @param item The item to add
+   * @return A Response with either an error message or the updated list.
+   */
+  protected abstract Response add(AWSSimpleSystemsManagement client, T[] list, T item);
+
+  /**
+   * Delete an item from the SSM list.
+   * @param client The SSM client to use.
+   * @param list The existing list.
+   * @param item The item to delete.
+   * @return A Response with either an error message or the updated list.
+   */
+  protected abstract Response delete(AWSSimpleSystemsManagement client, T[] list, T item);
+
+  /**
+   * Format the current list in a Response object.
+   * @param list The list to format
+   * @return A Response with the list.
+   */
+  protected abstract Response get(T[] list);
+
+
+  /**
+   * Query SSM to get the existing JSON list and deserialize it.
+   * @param client The SSM client.
+   * @return An error message, if any.
+   */
+  private String getList(AWSSimpleSystemsManagement client) {
+    GetParameterResult result = null;
+    String value = null;
+    try {
+      result = client.getParameter(new GetParameterRequest().withName(settingName));
+      value = result.getParameter().getValue();
+    } catch (ParameterNotFoundException exp) {
+      value = "[]";
+    }
+
+    try {
+      this.list = deserializeList(value);
+    } catch (Exception exp) {
+      return "Unable to parse app list from JSON.";
+    }
+
+    return "";
+  }
+
+  /**
+   * Write the updated list to SSM.
+   * @param client The SSM client to use.
+   * @param newList The updated list to write.
+   * @return An error message, if any.
+   */
+  protected String writeList(AWSSimpleSystemsManagement client, T[] newList) {
+    String json;
+    try {
+      json = new ObjectMapper().writeValueAsString(newList);
+    } catch (Exception exp) {
+      return "Unable to serialize updated list to JSON.";
+    }
+
+    try {
+      client.putParameter(new PutParameterRequest()
+          .withName(settingName)
+          .withValue(json)
+          .withType(ParameterType.String)
+          .withOverwrite(true));
+    } catch (Exception exp) {
+      return exp.getMessage();
+    }
+
+    return "";
+  }
+
+  public Command getCommand() {
+    return this.command;
+  }
+}

--- a/backend/main/src/main/java/sentiment/settings/SetSettingsResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/SetSettingsResponse.java
@@ -11,29 +11,18 @@ import java.util.Map;
  */
 public class SetSettingsResponse extends Response {
 
-  private Status status;
-  private String message;
-
   public SetSettingsResponse(String message) {
-    this.status = Status.ERROR;
-    this.message = message;
+    super(message);
   }
 
-  public SetSettingsResponse() {
-    this.status = Status.SUCCESS;
-  }
+  public SetSettingsResponse() { }
 
   /**
    * Return a map of JSON keys and values for this object.
    */
   @JsonAnyGetter
   public Map<String, Object> getData() {
-    Map<String, Object> data = new HashMap<String, Object>();
-
-    data.put("status", this.status);
-    data.put("message", this.message);
-
-    return data;
+    return super.getData();
   }
   
 }

--- a/backend/main/src/main/java/sentiment/stats/StatsRequest.java
+++ b/backend/main/src/main/java/sentiment/stats/StatsRequest.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.amazonaws.services.dynamodbv2.model.QueryResult;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -170,7 +172,9 @@ public class StatsRequest extends Request {
           nextIndex++;
           break;
         case "keywords":
-          results[nextIndex] = new KeywordsCalculation(items).calculate();
+          AWSSimpleSystemsManagement client = 
+              AWSSimpleSystemsManagementClientBuilder.defaultClient();
+          results[nextIndex] = new KeywordsCalculation(items, client).calculate();
           nextIndex++;
           break;
         case "sentimentOverTime":

--- a/backend/main/src/main/java/sentiment/stats/StatsResponse.java
+++ b/backend/main/src/main/java/sentiment/stats/StatsResponse.java
@@ -9,10 +9,7 @@ import java.util.Map;
  * A response to a query for sentiment statistics.
  */
 public class StatsResponse extends Response {
-  
-  private Status status;
-  private String message;
-  
+ 
   private String appIdStore;
   private String version;
   private OutgoingStat<?, ?>[] stats;
@@ -30,25 +27,21 @@ public class StatsResponse extends Response {
   }
 
   public StatsResponse(String message) {
-    this.status = Status.ERROR;
-    this.message = message;
+    super(message);
   }
 
   /**
    * Return a map of the JSON keys and values for this object.
    */
   public Map<String, Object> getData() {
-    Map<String, Object> data = new HashMap<String, Object>();
+    Map<String, Object> data = super.getData();
 
-    data.put("status", this.status);
-    if (this.stats != null) {
+    if (this.getStatus() == Status.SUCCESS) {
       data.put("appIdStore", appIdStore);
       data.put("version", version);
       for (OutgoingStat<?, ?> stat : stats) {
         data.put(stat.getName(), stat.getValues());
       }
-    } else {
-      data.put("message", this.message);
     }
     return data;
   }

--- a/backend/main/src/test/java/sentiment/settings/AppListTests.java
+++ b/backend/main/src/test/java/sentiment/settings/AppListTests.java
@@ -43,21 +43,21 @@ public class AppListTests {
     // Invalid app data should return error
     App app = new App("Valid Name", "Made-up Store", "Valid.ID");
     AppListRequest request = new AppListRequest("ADD", app);
-    AppListResponse response = request.addApp(new MockSSM(), new App[1]);
+    AppListResponse response = request.add(new MockSSM(), new App[1], app);
     AppListResponse expectedResponse = new AppListResponse("Invalid store Made-up Store.");
     assertThat(response.getData()).isEqualTo(expectedResponse.getData());
 
     // Adding existing app should return error
     app = new App("Valid Name", "App Store", "Valid.ID");
     request = new AppListRequest("ADD", app);
-    response = request.addApp(new MockSSM(), new App[]{ app });
+    response = request.add(new MockSSM(), new App[]{ app }, app);
     expectedResponse = new AppListResponse("App with id Valid.ID already exists in the list.");
     assertThat(response.getData()).isEqualTo(expectedResponse.getData());
 
     // Successful case (store values differ)
     App anotherApp = new App("Valid Name", "Google Play", "Valid.ID");
     request = new AppListRequest("ADD", anotherApp);
-    response = request.addApp(new MockSSM(), new App[]{ app });
+    response = request.add(new MockSSM(), new App[]{ app }, anotherApp);
 
     expectedResponse = new AppListResponse(new App[]{ app, anotherApp });
     Map<String, Object> expectedData = expectedResponse.getData();
@@ -68,7 +68,7 @@ public class AppListTests {
      // Successful case (id values differ)
      anotherApp = new App("Valid Name", "App Store", "Valid.ID2");
      request = new AppListRequest("ADD", anotherApp);
-     response = request.addApp(new MockSSM(), new App[]{ app });
+     response = request.add(new MockSSM(), new App[]{ app }, anotherApp);
  
      expectedResponse = new AppListResponse(new App[]{ app, anotherApp });
      expectedData = expectedResponse.getData();
@@ -82,7 +82,7 @@ public class AppListTests {
     // Invalid app data should return error
     App app = new App("Valid Name", "Made-up Store", "Valid.ID");
     AppListRequest request = new AppListRequest("ADD", app);
-    AppListResponse response = request.deleteApp(new MockSSM(), new App[1]);
+    AppListResponse response = request.delete(new MockSSM(), new App[1], app);
     AppListResponse expectedResponse = new AppListResponse("Invalid store Made-up Store.");
     assertThat(response.getData()).isEqualTo(expectedResponse.getData());
 
@@ -90,13 +90,13 @@ public class AppListTests {
     app = new App("Valid Name", "App Store", "Valid.ID");
     App anotherApp = new App("Valid Name", "App Store", "Valid.ID2");
     request = new AppListRequest("ADD", app);
-    response = request.deleteApp(new MockSSM(), new App[]{ anotherApp });
+    response = request.delete(new MockSSM(), new App[]{ anotherApp }, app);
     expectedResponse = new AppListResponse("No app with id Valid.ID present in list.");
     assertThat(response.getData()).isEqualTo(expectedResponse.getData());
 
     // Successful case
     request = new AppListRequest("ADD", anotherApp);
-    response = request.deleteApp(new MockSSM(), new App[]{ app, anotherApp });
+    response = request.delete(new MockSSM(), new App[]{ app, anotherApp }, anotherApp);
     
     expectedResponse = new AppListResponse(new App[]{ app });
     Map<String, Object> expectedData = expectedResponse.getData();

--- a/backend/main/src/test/java/sentiment/settings/IgnoreListTests.java
+++ b/backend/main/src/test/java/sentiment/settings/IgnoreListTests.java
@@ -1,0 +1,60 @@
+package sentiment.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import com.amazonaws.services.simplesystemsmanagement.AbstractAWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.PutParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.PutParameterResult;
+
+import org.junit.Test;
+
+public class IgnoreListTests {
+
+  private class MockSSM extends AbstractAWSSimpleSystemsManagement {
+    @Override
+    public PutParameterResult putParameter(PutParameterRequest request) {
+      return new PutParameterResult(); // No-op
+    }
+  }
+  
+  @Test
+  public void testAddKeyword() {
+    // Adding existing keyword should return error
+    IgnoreListRequest request = new IgnoreListRequest("ADD", "testKeyword");
+    IgnoreListResponse response = request.add(new MockSSM(), new String[]{ "testKeyword" }, "testKeyword");
+    IgnoreListResponse expectedResponse = new IgnoreListResponse("Keyword testKeyword already exists in the list.");
+    assertThat(response.getData()).isEqualTo(expectedResponse.getData());
+
+    // Successful case
+    request = new IgnoreListRequest("ADD", "testKeyword2");
+    response = request.add(new MockSSM(), new String[]{ "testKeyword" }, "testKeyword2");
+
+    expectedResponse = new IgnoreListResponse(new String[]{ "testKeyword", "testKeyword2" });
+    Map<String, Object> expectedData = expectedResponse.getData();
+    for (Map.Entry<String, Object> entry : response.getData().entrySet()) {
+      assertThat(entry.getValue()).isEqualTo(expectedData.get(entry.getKey()));
+    }
+  }
+
+  @Test
+  public void testDeleteKeyword() {
+    // Deleting nonexisting keyword should return error
+    IgnoreListRequest request = new IgnoreListRequest("ADD", "testKeyword2");
+    IgnoreListResponse response = request.delete(new MockSSM(), new String[]{ "testKeyword2" }, "testKeyword");
+    IgnoreListResponse expectedResponse = new IgnoreListResponse("No keyword testKeyword present in list.");
+    assertThat(response.getData()).isEqualTo(expectedResponse.getData());
+
+    // Successful case
+    request = new IgnoreListRequest("ADD", "testKeyword2");
+    response = request.delete(new MockSSM(), new String[]{ "testKeyword", "testKeyword2" }, "testKeyword2");
+    
+    expectedResponse = new IgnoreListResponse(new String[]{ "testKeyword" });
+    Map<String, Object> expectedData = expectedResponse.getData();
+    for (Map.Entry<String, Object> entry : response.getData().entrySet()) {
+      assertThat(entry.getValue()).isEqualTo(expectedData.get(entry.getKey()));
+    }
+  }
+
+}

--- a/backend/main/src/test/java/sentiment/stats/StatsTests.java
+++ b/backend/main/src/test/java/sentiment/stats/StatsTests.java
@@ -11,8 +11,20 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.simplesystemsmanagement.AbstractAWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
 
 public class StatsTests {
+
+  private class MockSSM extends AbstractAWSSimpleSystemsManagement {
+    @Override
+    public GetParameterResult getParameter(GetParameterRequest request) {
+      return new GetParameterResult()
+      .withParameter(new Parameter().withName("ignoreList-test").withValue("[]")); // No-op
+    }
+  }
 
 	@Test
 	public void testCalculateStats() {
@@ -153,7 +165,7 @@ public class StatsTests {
     reviews.add(populateReview("test store*test id", "2001-05-22T00:00:00.000Z", "1.0.0", "34895f", "POSITIVE", new String[]{"present always"}));
     reviews.add(populateReview("test store*test id", "2001-05-23T00:00:00.000Z", "1.0.0", "asldf4", "NEUTRAL", new String[]{"won't include neutral"}));
 
-    OutgoingStat<?, ?> result = new KeywordsCalculation(reviews).calculate();
+    OutgoingStat<?, ?> result = new KeywordsCalculation(reviews, new MockSSM()).calculate();
 
     Map<String, Keyword[]> keywords = new HashMap<String, Keyword[]>();
     keywords.put("positive", new Keyword[]{ new Keyword("present always", 100.0), new Keyword("present sometimes", 1.0 / 2 * 100)});

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -90,6 +90,11 @@ functions:
           authorizer: arn:aws:cognito-idp:us-east-2:948594532470:userpool/us-east-2_R99catdY3
       - http:
           method: post
+          path: settings/keywords
+          cors: true
+          authorizer: arn:aws:cognito-idp:us-east-2:948594532470:userpool/us-east-2_R99catdY3
+      - http:
+          method: post
           path: settings/get
           cors: true
           authorizer: arn:aws:cognito-idp:us-east-2:948594532470:userpool/us-east-2_R99catdY3

--- a/frontend/sentiment-dashboard/src/app/rest/domain.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/domain.ts
@@ -39,6 +39,12 @@ export interface App {
   appId: string;
 }
 
+export interface IgnoreListResponse {
+  ignoreList: string[];
+  status: string;
+  message: string;
+}
+
 export interface FilterInfo {
   name: string;
   minDate: string;

--- a/frontend/sentiment-dashboard/src/app/rest/rest.service.ts
+++ b/frontend/sentiment-dashboard/src/app/rest/rest.service.ts
@@ -3,7 +3,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {environment} from '../../environments/environment';
-import { StatResponse, StatRequest, Setting, SettingResponse, App, AppListResponse, FilterListResponse } from './domain';
+import { StatResponse,
+  StatRequest,
+  Setting,
+  SettingResponse,
+  App,
+  AppListResponse,
+  FilterListResponse,
+  IgnoreListResponse } from './domain';
 import { AuthService } from '../auth/auth.service';
 
 @Injectable({
@@ -113,5 +120,49 @@ export class RestService {
       app: app
     });
     return this.http.post<AppListResponse>(this.API_URL + 'settings/apps', body, options);
+  }
+
+  getIgnoreList(): Observable<IgnoreListResponse> {
+    const options = {
+      headers: new HttpHeaders(
+        {
+          'Content-Type' : 'application/json',
+          'Authorization' : this.apiKey
+        })
+    };
+    const body = JSON.stringify({
+      command: 'GET'
+    });
+    return this.http.post<IgnoreListResponse>(this.API_URL + 'settings/keywords', body, options);
+  }
+
+  addKeyword(keyword: string): Observable<IgnoreListResponse> {
+    const options = {
+      headers: new HttpHeaders(
+        {
+          'Content-Type' : 'application/json',
+          'Authorization' : this.apiKey
+        })
+    };
+    const body = JSON.stringify({
+      command: 'ADD',
+      keyword: keyword
+    });
+    return this.http.post<IgnoreListResponse>(this.API_URL + 'settings/keywords', body, options);
+  }
+
+  deleteKeyword(keyword: string): Observable<IgnoreListResponse> {
+    const options = {
+      headers: new HttpHeaders(
+        {
+          'Content-Type' : 'application/json',
+          'Authorization' : this.apiKey
+        })
+    };
+    const body = JSON.stringify({
+      command: 'DELETE',
+      keyword: keyword
+    });
+    return this.http.post<IgnoreListResponse>(this.API_URL + 'settings/keywords', body, options);
   }
 }

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.html
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.html
@@ -33,6 +33,27 @@
     </table>
 </div>
 
+<div class="row">
+  <h2 class="h4 mb-2">Ignored Keywords Management</h2>
+</div>
+<div class="alert alert-danger row" role="alert" *ngIf="ignoreListError !== ''">
+    Error: {{ ignoreListError }}
+  </div>
+<div class="alert alert-success row" role="alert" *ngIf="ignoreListSuccess">
+  Saved Successfully.
+</div>
+
+<div class="row mb-2">
+    <span *ngFor="let keyword of ignoreList" class="badge badge-primary mx-1" (click)="onDeleteKeyword(keyword)">{{ keyword }} &times;</span>
+</div>
+<form [formGroup]="ignoreListForm" (ngSubmit)="onAddKeyword()">
+  <div class="row mb-4">
+    <input type="text" class="form-control" id="add-keyword" formControlName="addKeyword" [class.is-invalid]="addKeyword.invalid">
+    <button type="submit" class="btn btn-primary my-2">Add Keyword</button>
+  </div>
+</form>
+
+
 
 <div class="row mb-4 border-bottom">
   <h2 class="h4">Scraper Settings</h2>

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.scss
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.scss
@@ -1,3 +1,7 @@
 td {
   border-top: none;
 }
+
+.badge {
+  font-size: 100% !important;
+}

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.spec.ts
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.spec.ts
@@ -5,7 +5,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { environment } from 'src/environments/environment';
-import { SettingResponse, App, AppListResponse } from '../rest/domain';
+import { SettingResponse, App, AppListResponse, IgnoreListResponse } from '../rest/domain';
 import { AuthService } from '../auth/auth.service';
 import { ModalModule, BsModalService } from 'ngx-bootstrap/modal';
 import { ComponentLoaderFactory } from 'ngx-bootstrap';
@@ -76,6 +76,13 @@ describe('SettingsComponent', () => {
       message: null
     };
 
+    const testIgnoreList: string[] = ['test', 'keyword', 'list'];
+    const testIgnoreListResponse: IgnoreListResponse = {
+      ignoreList: testIgnoreList,
+      status: 'SUCCESS',
+      message: null
+    };
+
     const reqs = httpMock.match(API_URL + 'settings/get');
     reqs.forEach((req) => {
       if (req.request.body === JSON.stringify({names: ['pollingInterval']})) {
@@ -88,6 +95,9 @@ describe('SettingsComponent', () => {
     const appListReq = httpMock.expectOne(API_URL + 'settings/apps');
     appListReq.flush(testAppListResponse);
 
+    const ignoreListReq = httpMock.expectOne(API_URL + 'settings/keywords');
+    ignoreListReq.flush(testIgnoreListResponse);
+
     httpMock.verify();
 
     expect(component.pollingInterval.value).toEqual(testPollingInterval);
@@ -96,6 +106,7 @@ describe('SettingsComponent', () => {
     expect(component.postingInterval.value).toEqual(testPostingInterval);
 
     expect(component.appList).toEqual(testAppList);
+    expect(component.ignoreList).toEqual(testIgnoreList);
   }
 
   it('should create', () => {
@@ -176,11 +187,15 @@ describe('SettingsComponent', () => {
     const appListReq = httpMock.expectOne(API_URL + 'settings/apps');
     appListReq.flush(testResponse);
 
+    const ignoreListReq = httpMock.expectOne(API_URL + 'settings/keywords');
+    ignoreListReq.flush(testResponse);
+
     httpMock.verify();
 
     expect(component.scrapingFormError).toEqual('Test Error Message');
     expect(component.slackFormError).toEqual('Test Error Message');
     expect(component.appListError).toEqual('Test Error Message');
+    expect(component.ignoreListError).toEqual('Test Error Message');
   });
 
   it('should display a success message on save for a time interval', async() => {
@@ -213,6 +228,12 @@ describe('SettingsComponent', () => {
       ]
     };
 
+    const testIgnoreListSuccessResponse: IgnoreListResponse = {
+      message: null,
+      status: 'SUCCESS',
+      ignoreList: ['test', 'keyword', 'list']
+    };
+
     component.onScrapingSubmit();
     let req = httpMock.expectOne(API_URL + 'settings/set');
     req.flush(testSuccessResponse);
@@ -233,6 +254,19 @@ describe('SettingsComponent', () => {
     req = httpMock.expectOne(API_URL + 'settings/apps');
     req.flush(testAppListSuccessResponse);
     expect(component.appListSuccess).toBeTruthy();
+
+    component.addKeyword.setValue('anotherKeyword');
+    component.addKeyword.updateValueAndValidity();
+    component.onAddKeyword();
+    req = httpMock.expectOne(API_URL + 'settings/keywords');
+    req.flush(testIgnoreListSuccessResponse);
+    expect(component.ignoreListSuccess).toBeTruthy();
+
+    const toDeleteKeyword = component.ignoreList[0];
+    component.onDeleteKeyword(toDeleteKeyword);
+    req = httpMock.expectOne(API_URL + 'settings/keywords');
+    req.flush(testIgnoreListSuccessResponse);
+    expect(component.ignoreListSuccess).toBeTruthy();
 
     httpMock.verify();
   });
@@ -308,6 +342,28 @@ describe('SettingsComponent', () => {
     };
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual(JSON.stringify(expectedAppListDeleteRequest));
+
+    const toAddKeyword = 'add';
+    component.addKeyword.setValue(toAddKeyword);
+    component.addKeyword.updateValueAndValidity();
+    component.onAddKeyword();
+    req = httpMock.expectOne(API_URL + 'settings/keywords');
+    const expectedIgnoreListAddRequest = {
+      command: 'ADD',
+      keyword: toAddKeyword
+    };
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual(JSON.stringify(expectedIgnoreListAddRequest));
+
+    const toDeleteKeyword: string = component.ignoreList[0];
+    component.onDeleteKeyword(toDeleteKeyword);
+    req = httpMock.expectOne(API_URL + 'settings/keywords');
+    const expectedIgnoreListDeleteRequest = {
+      command: 'DELETE',
+      keyword: toDeleteKeyword
+    };
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual(JSON.stringify(expectedIgnoreListDeleteRequest));
 
     httpMock.verify();
   });


### PR DESCRIPTION
First pass on keywords - both the backend API and the frontend interface are functional, and words on the ignore list are not used when calculating the top keywords. 

However, the current interface is still very difficult to use as a result of the sheer amount of common words that Comprehend flags. Some ideas for the future:
- Lowercase all keywords (either during scraping or during keyword calculation)
- Allow regex in the ignore list
- Throw out keywords if even part of the phrase is present in the ignore list (as opposed to an exact match)