### PR TITLE
Fix/better keyword calculation

### DIFF
--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.html
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.html
@@ -73,12 +73,12 @@
 </div>
 
 <div class="row mb-2">
-    <span *ngFor="let keyword of ignoreList" class="badge badge-primary mx-1" (click)="onDeleteKeyword(keyword)">{{ keyword }} &times;</span>
+    <span *ngFor="let keyword of ignoreList" class="badge badge-primary m-1" (click)="onDeleteKeyword(keyword)">{{ keyword }} &times;</span>
 </div>
 <form [formGroup]="ignoreListForm" (ngSubmit)="onAddKeyword()">
   <div class="row mb-4">
     <input type="text" class="form-control" id="add-keyword" formControlName="addKeyword" [class.is-invalid]="addKeyword.invalid">
-    <button type="submit" class="btn btn-primary my-2">Add Keyword</button>
+    <button type="submit" class="btn btn-primary my-2" [disabled]="addKeyword.invalid">Add Keyword</button>
   </div>
 </form>
 

--- a/frontend/sentiment-dashboard/src/app/settings/settings.component.scss
+++ b/frontend/sentiment-dashboard/src/app/settings/settings.component.scss
@@ -5,3 +5,7 @@ td {
 .badge {
   font-size: 100% !important;
 }
+
+span {
+  cursor: pointer;
+}


### PR DESCRIPTION
Fixes to allow quicker and easier keyword configuration. The system now removes partial matches for keywords in the ignore list (ex: "car" matches both "the car" and "this car" in addition to "car"). I also made some tweaks to the Ignore List UI to clean up a few things - disabling the "submit" button if the form is invalid, and fixing up the margins on the keyword chips.