### PR TITLE
Fix/keywords percentages

### DIFF
--- a/backend/main/src/main/java/sentiment/settings/AppListResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/AppListResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 
 import sentiment.Response;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/backend/main/src/main/java/sentiment/settings/GetSettingsResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/GetSettingsResponse.java
@@ -3,7 +3,6 @@ package sentiment.settings;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import sentiment.Response;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/backend/main/src/main/java/sentiment/settings/IgnoreListResponse.java
+++ b/backend/main/src/main/java/sentiment/settings/IgnoreListResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 
 import sentiment.Response;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/backend/main/src/main/java/sentiment/stats/OutgoingStat.java
+++ b/backend/main/src/main/java/sentiment/stats/OutgoingStat.java
@@ -1,9 +1,7 @@
 package sentiment.stats;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/backend/main/src/main/java/sentiment/stats/StatsRequest.java
+++ b/backend/main/src/main/java/sentiment/stats/StatsRequest.java
@@ -9,23 +9,15 @@ import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import sentiment.Request;
 import sentiment.Response;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Stream;
 
 
 /**

--- a/backend/main/src/main/java/sentiment/stats/StatsResponse.java
+++ b/backend/main/src/main/java/sentiment/stats/StatsResponse.java
@@ -2,7 +2,6 @@ package sentiment.stats;
 
 import sentiment.Response;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**


### PR DESCRIPTION
Ever wonder why all our keyword percentages were super low and also contained a lot of duplicates? Yeah, me too - also Dr. D pointed it out in our beta presentation.

The answer is: I was dividing by the wrong totals this entire time, and I never questioned the percentage values until now (oops). I should have been using the total number of reviews, and instead I was dividing by the total number of keywords (which produces a significantly less useful value). Should be fixed now - I'll take this as a sign that I shouldn't code while sleep deprived.